### PR TITLE
fix: actually write manifest file in the pipeline

### DIFF
--- a/.github/workflows/refresh-manifest.yml
+++ b/.github/workflows/refresh-manifest.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-go@v6
 
-      - run: go run tools/manifest-refresher/main.go
+      - run: go run tools/manifest-refresher/main.go > manifest.json
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7


### PR DESCRIPTION
As above, we weren't writing the actual file during the pipeline execution